### PR TITLE
Add FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+__pycache__/
+*.py[cod]
+

--- a/README.md
+++ b/README.md
@@ -2,13 +2,23 @@
 
 This contains everything you need to run your app locally.
 
-## Run Locally
+## Frontend
 
-**Prerequisites:**  Node.js
-
+**Prerequisites:** Node.js
 
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Backend
+
+**Prerequisites:** Python 3.11+
+
+1. Navigate to the backend folder:
+   `cd backend`
+2. Install dependencies:
+   `pip install fastapi uvicorn sqlalchemy pydantic`
+3. Run the server:
+   `uvicorn main:app --reload`

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,8 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///./app.db'
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+# Dependency
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.get("/users", response_model=list[schemas.User])
+def read_users(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(models.User).offset(skip).limit(limit).all()
+
+@app.post("/users", response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = models.User(name=user.name, email=user.email)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+@app.get("/products", response_model=list[schemas.Product])
+def read_products(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(models.Product).offset(skip).limit(limit).all()
+
+@app.post("/products", response_model=schemas.Product)
+def create_product(product: schemas.ProductCreate, db: Session = Depends(get_db)):
+    db_product = models.Product(name=product.name, price=product.price)
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+    return db_product
+
+@app.get("/orders", response_model=list[schemas.Order])
+def read_orders(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(models.Order).offset(skip).limit(limit).all()
+
+@app.post("/orders", response_model=schemas.Order)
+def create_order(order: schemas.OrderCreate, db: Session = Depends(get_db)):
+    # verify user and product exist
+    user = db.get(models.User, order.user_id)
+    product = db.get(models.Product, order.product_id)
+    if not user or not product:
+        raise HTTPException(status_code=400, detail="Invalid user or product")
+    db_order = models.Order(user_id=order.user_id, product_id=order.product_id)
+    db.add(db_order)
+    db.commit()
+    db.refresh(db_order)
+    return db_order

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Column, Integer, String, Float, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    email = Column(String, unique=True, index=True)
+
+    orders = relationship('Order', back_populates='user')
+
+class Product(Base):
+    __tablename__ = 'products'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    price = Column(Float)
+
+    orders = relationship('Order', back_populates='product')
+
+class Order(Base):
+    __tablename__ = 'orders'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    product_id = Column(Integer, ForeignKey('products.id'))
+
+    user = relationship('User', back_populates='orders')
+    product = relationship('Product', back_populates='orders')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    name: str
+    email: str
+
+class UserCreate(UserBase):
+    pass
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class ProductBase(BaseModel):
+    name: str
+    price: float
+
+class ProductCreate(ProductBase):
+    pass
+
+class Product(ProductBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class OrderBase(BaseModel):
+    user_id: int
+    product_id: int
+
+class OrderCreate(OrderBase):
+    pass
+
+class Order(OrderBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- introduce a `backend` folder
- implement minimal FastAPI app with SQLite and SQLAlchemy
- document how to run the backend server
- update `.gitignore` for Python artifacts

## Testing
- `npm run build` *(fails: Could not resolve ./src/App)*

------
https://chatgpt.com/codex/tasks/task_e_688d08a84e7c83229723286b65ead44b